### PR TITLE
Update ti.parse_mine.js

### DIFF
--- a/app/lib/ti.parse_mine.js
+++ b/app/lib/ti.parse_mine.js
@@ -101,7 +101,6 @@ var TiParse = function(options) {
     },
     init : function() {
       Ti.API.debug("called FB.init()");
-      TiFacebook.appid = '175961759252181';
     },
     login : function() {
       Ti.API.debug("called FB.login()");


### PR DESCRIPTION
Remove the hardcoded facebook appid in the init function as it would overwrite the one passed as a parameter in the options section.

removing:      TiFacebook.appid = '175961759252181';
